### PR TITLE
Make arguments for add and filter transactions optional, other fixes for filter

### DIFF
--- a/src/main/java/seedu/ichifund/logic/commands/transaction/AddTransactionCommand.java
+++ b/src/main/java/seedu/ichifund/logic/commands/transaction/AddTransactionCommand.java
@@ -9,11 +9,21 @@ import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_MONTH;
 import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_TRANSACTION_TYPE;
 import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_YEAR;
 
+import java.util.Optional;
+
 import seedu.ichifund.logic.commands.Command;
 import seedu.ichifund.logic.commands.CommandResult;
 import seedu.ichifund.logic.commands.exceptions.CommandException;
+import seedu.ichifund.model.Description;
 import seedu.ichifund.model.Model;
+import seedu.ichifund.model.amount.Amount;
+import seedu.ichifund.model.date.Date;
+import seedu.ichifund.model.date.Day;
+import seedu.ichifund.model.date.Month;
+import seedu.ichifund.model.date.Year;
+import seedu.ichifund.model.transaction.Category;
 import seedu.ichifund.model.transaction.Transaction;
+import seedu.ichifund.model.transaction.TransactionType;
 
 /**
  * Adds a transaction to IchiFund.
@@ -26,7 +36,7 @@ public class AddTransactionCommand extends Command {
             + "Parameters: "
             + PREFIX_DESCRIPTION + "DESCRIPTION "
             + PREFIX_AMOUNT + "AMOUNT "
-            + PREFIX_CATEGORY + "CATEGORY "
+            + "[" + PREFIX_CATEGORY + "CATEGORY] "
             + "[" + PREFIX_DAY + "DAY] "
             + "[" + PREFIX_MONTH + "MONTH] "
             + "[" + PREFIX_YEAR + "YEAR] "
@@ -64,5 +74,47 @@ public class AddTransactionCommand extends Command {
         return other == this // short circuit if same object
                 || (other instanceof AddTransactionCommand // instanceof handles nulls
                 && toAdd.equals(((AddTransactionCommand) other).toAdd));
+    }
+
+    static public class AddTransactionCommandBuilder {
+        Description description;
+        Amount amount;
+        Optional<Category> category;
+        Optional<Day> day;
+        Optional<Month> month;
+        Optional<Year> year;
+        Optional<TransactionType> transactionType;
+
+        public void setDescription(Description description) {
+            this.description = description;
+        }
+
+        public void setAmount(Amount amount) {
+            this.amount = amount;
+        }
+
+        public void setCategory(Optional<Category> category) {
+            this.category = category;
+        }
+
+        public void setDay(Optional<Day> day) {
+            this.day = day;
+        }
+
+        public void setMonth(Optional<Month> month) {
+            this.month = month;
+        }
+
+        public void setYear(Optional<Year> year) {
+            this.year = year;
+        }
+
+        public void setTransactionType(Optional<TransactionType> transactionType) {
+            this.transactionType = transactionType;
+        }
+
+        public AddTransactionCommand build() {
+            return new AddTransactionCommand(description, amount, category, day, month, year, transactionType);
+        }
     }
 }

--- a/src/main/java/seedu/ichifund/logic/commands/transaction/AddTransactionCommand.java
+++ b/src/main/java/seedu/ichifund/logic/commands/transaction/AddTransactionCommand.java
@@ -161,6 +161,7 @@ public class AddTransactionCommand extends Command {
         }
 
         public AddTransactionCommand build() {
+            requireAllNonNull(description, amount, category, day, month, year, transactionType);
             return new AddTransactionCommand(description, amount, category, day, month, year, transactionType);
         }
 

--- a/src/main/java/seedu/ichifund/logic/commands/transaction/AddTransactionCommand.java
+++ b/src/main/java/seedu/ichifund/logic/commands/transaction/AddTransactionCommand.java
@@ -83,6 +83,13 @@ public class AddTransactionCommand extends Command {
         this.transactionType = transactionType;
     }
 
+    /**
+     * Returns a {@code Transaction} object based on fields, as well as the given context.
+     *
+     * @param context Context from which values of unspecified fields are inferred.
+     * @return {@code Transaction} object generated.
+     * @throws CommandException If date generated is not valid.
+     */
     private Transaction generateTransaction(TransactionContext context) throws CommandException {
         Category category = this.category.orElseGet(context::getCategory);
         Date date = generateDate(context);
@@ -90,6 +97,13 @@ public class AddTransactionCommand extends Command {
         return new Transaction(description, amount, category, date, transactionType);
     }
 
+    /**
+     * Returns a {@code Date} object based on fields, as well as the given context.
+     *
+     * @param context Context form which values of unspecified fields are inferred.
+     * @return {@code Date} object generated.
+     * @throws CommandException If date generated is not valid.
+     */
     private Date generateDate(TransactionContext context) throws CommandException {
         Day day = this.day.orElseGet(Day::getCurrent);
         Month month = this.month.orElseGet(context::getMonth);
@@ -123,14 +137,17 @@ public class AddTransactionCommand extends Command {
                 && transactionType.equals(((AddTransactionCommand) other).transactionType));
     }
 
-    static public class AddTransactionCommandBuilder {
-        Description description;
-        Amount amount;
-        Optional<Category> category;
-        Optional<Day> day;
-        Optional<Month> month;
-        Optional<Year> year;
-        Optional<TransactionType> transactionType;
+    /**
+     * Builder class to construct an AddTransactionCommand.
+     */
+    public static class AddTransactionCommandBuilder {
+        private Description description;
+        private Amount amount;
+        private Optional<Category> category;
+        private Optional<Day> day;
+        private Optional<Month> month;
+        private Optional<Year> year;
+        private Optional<TransactionType> transactionType;
 
         public void setDescription(Description description) {
             this.description = description;
@@ -160,6 +177,12 @@ public class AddTransactionCommand extends Command {
             this.transactionType = transactionType;
         }
 
+        /**
+         * Returns a {@code AddTransactionCommand} built from the builder.
+         * All fields must be non-null.
+         *
+         * @return The command corresponding to the builder
+         */
         public AddTransactionCommand build() {
             requireAllNonNull(description, amount, category, day, month, year, transactionType);
             return new AddTransactionCommand(description, amount, category, day, month, year, transactionType);

--- a/src/main/java/seedu/ichifund/logic/commands/transaction/AddTransactionCommand.java
+++ b/src/main/java/seedu/ichifund/logic/commands/transaction/AddTransactionCommand.java
@@ -120,7 +120,7 @@ public class AddTransactionCommand extends Command {
                 && day.equals(((AddTransactionCommand) other).day)
                 && month.equals(((AddTransactionCommand) other).month)
                 && year.equals(((AddTransactionCommand) other).year)
-                && transactionType.equals(((AddTransactionCommand) other).transactionType);
+                && transactionType.equals(((AddTransactionCommand) other).transactionType));
     }
 
     static public class AddTransactionCommandBuilder {
@@ -174,7 +174,7 @@ public class AddTransactionCommand extends Command {
                     && day.equals(((AddTransactionCommandBuilder) other).day)
                     && month.equals(((AddTransactionCommandBuilder) other).month)
                     && year.equals(((AddTransactionCommandBuilder) other).year)
-                    && transactionType.equals(((AddTransactionCommandBuilder) other).transactionType);
+                    && transactionType.equals(((AddTransactionCommandBuilder) other).transactionType));
         }
     }
 }

--- a/src/main/java/seedu/ichifund/logic/commands/transaction/AddTransactionCommand.java
+++ b/src/main/java/seedu/ichifund/logic/commands/transaction/AddTransactionCommand.java
@@ -27,10 +27,10 @@ public class AddTransactionCommand extends Command {
             + PREFIX_DESCRIPTION + "DESCRIPTION "
             + PREFIX_AMOUNT + "AMOUNT "
             + PREFIX_CATEGORY + "CATEGORY "
-            + PREFIX_DAY + "DAY "
-            + PREFIX_MONTH + "MONTH "
-            + PREFIX_YEAR + "YEAR "
-            + PREFIX_TRANSACTION_TYPE + "TRANSACTION_TYPE "
+            + "[" + PREFIX_DAY + "DAY] "
+            + "[" + PREFIX_MONTH + "MONTH] "
+            + "[" + PREFIX_YEAR + "YEAR] "
+            + "[" + PREFIX_TRANSACTION_TYPE + "TRANSACTION_TYPE] "
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_DESCRIPTION + "Buy lunch "
             + PREFIX_AMOUNT + "5.28 "
@@ -38,7 +38,7 @@ public class AddTransactionCommand extends Command {
             + PREFIX_DAY + "5 "
             + PREFIX_MONTH + "10 "
             + PREFIX_YEAR + "2019 "
-            + PREFIX_TRANSACTION_TYPE + "expenditure ";
+            + PREFIX_TRANSACTION_TYPE + "exp ";
 
     public static final String MESSAGE_SUCCESS = "New transaction added: %1$s";
 

--- a/src/main/java/seedu/ichifund/logic/commands/transaction/AddTransactionCommand.java
+++ b/src/main/java/seedu/ichifund/logic/commands/transaction/AddTransactionCommand.java
@@ -1,6 +1,7 @@
 package seedu.ichifund.logic.commands.transaction;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.ichifund.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_DAY;
@@ -17,6 +18,7 @@ import seedu.ichifund.logic.commands.exceptions.CommandException;
 import seedu.ichifund.model.Description;
 import seedu.ichifund.model.Model;
 import seedu.ichifund.model.amount.Amount;
+import seedu.ichifund.model.context.TransactionContext;
 import seedu.ichifund.model.date.Date;
 import seedu.ichifund.model.date.Day;
 import seedu.ichifund.model.date.Month;
@@ -32,7 +34,12 @@ public class AddTransactionCommand extends Command {
 
     public static final String COMMAND_WORD = "addtx";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a transaction to IchiFund. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a transaction to IchiFund "
+            + "and switches view to show new transaction. \n"
+            + "If unspecified, transactions occur on the day of the month in system time, "
+            + "and the month and year in the current list view. \n"
+            + "If unspecified, the category and type of transactions follow the current list view where applicable. "
+            + "Otherwise, transactions are uncategorised expenditure items by default.\n"
             + "Parameters: "
             + PREFIX_DESCRIPTION + "DESCRIPTION "
             + PREFIX_AMOUNT + "AMOUNT "
@@ -52,19 +59,53 @@ public class AddTransactionCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New transaction added: %1$s";
 
-    private final Transaction toAdd;
+    private final Description description;
+    private final Amount amount;
+    private final Optional<Category> category;
+    private final Optional<Day> day;
+    private final Optional<Month> month;
+    private final Optional<Year> year;
+    private final Optional<TransactionType> transactionType;
 
     /**
      * Creates an AddCommand to add the specified {@code Transaction}
      */
-    public AddTransactionCommand(Transaction transaction) {
-        requireNonNull(transaction);
-        toAdd = transaction;
+    public AddTransactionCommand(Description description, Amount amount, Optional<Category> category,
+                                 Optional<Day> day, Optional<Month> month, Optional<Year> year,
+                                 Optional<TransactionType> transactionType) {
+        requireAllNonNull(description, amount, category, day, month, year, transactionType);
+        this.description = description;
+        this.amount = amount;
+        this.category = category;
+        this.day = day;
+        this.month = month;
+        this.year = year;
+        this.transactionType = transactionType;
+    }
+
+    private Transaction generateTransaction(TransactionContext context) throws CommandException {
+        Category category = this.category.orElseGet(context::getCategory);
+        Date date = generateDate(context);
+        TransactionType transactionType = this.transactionType.orElseGet(context::getTransactionType);
+        return new Transaction(description, amount, category, date, transactionType);
+    }
+
+    private Date generateDate(TransactionContext context) throws CommandException {
+        Day day = this.day.orElseGet(Day::getCurrent);
+        Month month = this.month.orElseGet(context::getMonth);
+        Year year = this.year.orElseGet(context::getYear);
+        if (!Date.isValidDate(day, month, year)) {
+            throw new CommandException(Date.MESSAGE_CONSTRAINTS);
+        } else {
+            return new Date(day, month, year);
+        }
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        TransactionContext context = model.getTransactionContext();
+        Transaction toAdd = generateTransaction(context);
         model.addTransaction(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
@@ -73,7 +114,13 @@ public class AddTransactionCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof AddTransactionCommand // instanceof handles nulls
-                && toAdd.equals(((AddTransactionCommand) other).toAdd));
+                && description.equals(((AddTransactionCommand) other).description) // state check
+                && amount.equals(((AddTransactionCommand) other).amount)
+                && category.equals(((AddTransactionCommand) other).category)
+                && day.equals(((AddTransactionCommand) other).day)
+                && month.equals(((AddTransactionCommand) other).month)
+                && year.equals(((AddTransactionCommand) other).year)
+                && transactionType.equals(((AddTransactionCommand) other).transactionType);
     }
 
     static public class AddTransactionCommandBuilder {
@@ -115,6 +162,19 @@ public class AddTransactionCommand extends Command {
 
         public AddTransactionCommand build() {
             return new AddTransactionCommand(description, amount, category, day, month, year, transactionType);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other == this // short circuit if same object
+                    || (other instanceof AddTransactionCommandBuilder // instanceof handles nulls
+                    && description.equals(((AddTransactionCommandBuilder) other).description) // state check
+                    && amount.equals(((AddTransactionCommandBuilder) other).amount)
+                    && category.equals(((AddTransactionCommandBuilder) other).category)
+                    && day.equals(((AddTransactionCommandBuilder) other).day)
+                    && month.equals(((AddTransactionCommandBuilder) other).month)
+                    && year.equals(((AddTransactionCommandBuilder) other).year)
+                    && transactionType.equals(((AddTransactionCommandBuilder) other).transactionType);
         }
     }
 }

--- a/src/main/java/seedu/ichifund/logic/commands/transaction/FilterTransactionCommand.java
+++ b/src/main/java/seedu/ichifund/logic/commands/transaction/FilterTransactionCommand.java
@@ -1,8 +1,10 @@
 package seedu.ichifund.logic.commands.transaction;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.ichifund.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_MONTH;
+import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_TRANSACTION_TYPE;
 import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_YEAR;
 
 import java.util.Optional;
@@ -15,6 +17,7 @@ import seedu.ichifund.model.Model;
 import seedu.ichifund.model.date.Month;
 import seedu.ichifund.model.date.Year;
 import seedu.ichifund.model.transaction.Category;
+import seedu.ichifund.model.transaction.TransactionType;
 
 /**
  * Filters the list of transaction in IchiFund by Year, Month, and optionally Category.
@@ -24,26 +27,33 @@ public class FilterTransactionCommand extends Command {
     public static final String COMMAND_WORD = "filtertx";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all transactions from a specified "
-            + "month, year and optionally category, and displays them as a list with index numbers. "
+            + "month, year and optionally category, and displays them as a list with index numbers.\n"
             + "To show all categories, use "
             + PREFIX_CATEGORY + Category.CATEGORY_ALL.toString() + "\n"
+            + "To show both income and expenditure items, use "
+            + PREFIX_TRANSACTION_TYPE + TransactionType.TRANSACTION_TYPE_ALL.toString() + "\n"
             + "Parameters: "
             + PREFIX_MONTH + "MONTH "
             + PREFIX_YEAR + "YEAR "
             + "[" + PREFIX_CATEGORY + "CATEGORY] "
+            + "[" + PREFIX_TRANSACTION_TYPE + "TRANSACTION_TYPE] "
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_MONTH + "10 "
             + PREFIX_YEAR + "2019 "
-            + PREFIX_CATEGORY + "food ";
+            + PREFIX_CATEGORY + "!all "
+            + PREFIX_TRANSACTION_TYPE + "exp ";
 
     private final Month month;
     private final Year year;
     private final Optional<Category> category;
+    private final Optional<TransactionType> transactionType;
 
-    public FilterTransactionCommand(Month month, Year year, Optional<Category> category) {
+    public FilterTransactionCommand(Month month, Year year, Optional<Category> category,
+                                    Optional<TransactionType> transactionType) {
         this.month = month;
         this.year = year;
         this.category = category;
+        this.transactionType = transactionType;
     }
 
     @Override
@@ -51,9 +61,10 @@ public class FilterTransactionCommand extends Command {
         requireNonNull(model);
         model.setTransactionContext(
                 model.getTransactionContext()
-                        .getUpdatedContext(month)
-                        .getUpdatedContext(year)
-                        .getUpdatedContext(category)
+                        .withMonth(month)
+                        .withYear(year)
+                        .withCategory(category)
+                        .withType(transactionType)
         );
         return new CommandResult(
                 String.format(Messages.MESSAGE_TRANSACTIONS_LISTED_OVERVIEW,
@@ -67,5 +78,33 @@ public class FilterTransactionCommand extends Command {
                 && month.equals(((FilterTransactionCommand) other).month)
                 && year.equals(((FilterTransactionCommand) other).year)
                 && category.equals(((FilterTransactionCommand) other).category)); // state check
+    }
+
+    public static class FilterTransactionCommandBuilder {
+        private Month month;
+        private Year year;
+        private Optional<Category> category;
+        private Optional<TransactionType> transactionType;
+
+        public void setMonth(Month month) {
+            this.month = month;
+        }
+
+        public void setYear(Year year) {
+            this.year = year;
+        }
+
+        public void setCategory(Optional<Category> category) {
+            this.category = category;
+        }
+
+        public void setType(Optional<TransactionType> transactionType) {
+            this.transactionType = transactionType;
+        }
+
+        public FilterTransactionCommand build() {
+            requireAllNonNull(month, year, category, transactionType);
+            return new FilterTransactionCommand(month, year, category, transactionType);
+        }
     }
 }

--- a/src/main/java/seedu/ichifund/logic/commands/transaction/FilterTransactionCommand.java
+++ b/src/main/java/seedu/ichifund/logic/commands/transaction/FilterTransactionCommand.java
@@ -24,7 +24,9 @@ public class FilterTransactionCommand extends Command {
     public static final String COMMAND_WORD = "filtertx";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all transactions from a specified "
-            + "month, year and optionally category, and displays them as a list with index numbers.\n"
+            + "month, year and optionally category, and displays them as a list with index numbers. "
+            + "To show all categories, use "
+            + PREFIX_CATEGORY + Category.CATEGORY_ALL.toString() + "\n"
             + "Parameters: "
             + PREFIX_MONTH + "MONTH "
             + PREFIX_YEAR + "YEAR "

--- a/src/main/java/seedu/ichifund/logic/commands/transaction/FilterTransactionCommand.java
+++ b/src/main/java/seedu/ichifund/logic/commands/transaction/FilterTransactionCommand.java
@@ -29,12 +29,13 @@ public class FilterTransactionCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all transactions from a specified "
             + "month, year and optionally category, and displays them as a list with index numbers.\n"
             + "To show all categories, use "
-            + PREFIX_CATEGORY + Category.CATEGORY_ALL.toString() + "\n"
+            + "\"" + PREFIX_CATEGORY + Category.CATEGORY_ALL.toString() + "\". "
             + "To show both income and expenditure items, use "
-            + PREFIX_TRANSACTION_TYPE + TransactionType.TRANSACTION_TYPE_ALL.toString() + "\n"
+            + "\"" + PREFIX_TRANSACTION_TYPE + TransactionType.TRANSACTION_TYPE_ALL.toString() + "\"."
+            + "At least one parameter must be present.\n"
             + "Parameters: "
-            + PREFIX_MONTH + "MONTH "
-            + PREFIX_YEAR + "YEAR "
+            + "[" + PREFIX_MONTH + "MONTH] "
+            + "[" + PREFIX_YEAR + "YEAR] "
             + "[" + PREFIX_CATEGORY + "CATEGORY] "
             + "[" + PREFIX_TRANSACTION_TYPE + "TRANSACTION_TYPE] "
             + "Example: " + COMMAND_WORD + " "
@@ -80,6 +81,9 @@ public class FilterTransactionCommand extends Command {
                 && category.equals(((FilterTransactionCommand) other).category)); // state check
     }
 
+    /**
+     * Builder class to construct a FilterTransactionCommand.
+     */
     public static class FilterTransactionCommandBuilder {
         private Optional<Month> month;
         private Optional<Year> year;
@@ -102,6 +106,12 @@ public class FilterTransactionCommand extends Command {
             this.transactionType = transactionType;
         }
 
+        /**
+         * Builds a {@code FilterTransactionCommand} from the builder.
+         * All fields must be non-null.
+         *
+         * @return The command corresponding to the builder
+         */
         public FilterTransactionCommand build() {
             requireAllNonNull(month, year, category, transactionType);
             return new FilterTransactionCommand(month, year, category, transactionType);

--- a/src/main/java/seedu/ichifund/logic/commands/transaction/FilterTransactionCommand.java
+++ b/src/main/java/seedu/ichifund/logic/commands/transaction/FilterTransactionCommand.java
@@ -107,7 +107,7 @@ public class FilterTransactionCommand extends Command {
         }
 
         /**
-         * Builds a {@code FilterTransactionCommand} from the builder.
+         * Returns a {@code FilterTransactionCommand} built from the builder.
          * All fields must be non-null.
          *
          * @return The command corresponding to the builder

--- a/src/main/java/seedu/ichifund/logic/commands/transaction/FilterTransactionCommand.java
+++ b/src/main/java/seedu/ichifund/logic/commands/transaction/FilterTransactionCommand.java
@@ -43,12 +43,12 @@ public class FilterTransactionCommand extends Command {
             + PREFIX_CATEGORY + "!all "
             + PREFIX_TRANSACTION_TYPE + "exp ";
 
-    private final Month month;
-    private final Year year;
+    private final Optional<Month> month;
+    private final Optional<Year> year;
     private final Optional<Category> category;
     private final Optional<TransactionType> transactionType;
 
-    public FilterTransactionCommand(Month month, Year year, Optional<Category> category,
+    public FilterTransactionCommand(Optional<Month> month, Optional<Year> year, Optional<Category> category,
                                     Optional<TransactionType> transactionType) {
         this.month = month;
         this.year = year;
@@ -81,16 +81,16 @@ public class FilterTransactionCommand extends Command {
     }
 
     public static class FilterTransactionCommandBuilder {
-        private Month month;
-        private Year year;
+        private Optional<Month> month;
+        private Optional<Year> year;
         private Optional<Category> category;
         private Optional<TransactionType> transactionType;
 
-        public void setMonth(Month month) {
+        public void setMonth(Optional<Month> month) {
             this.month = month;
         }
 
-        public void setYear(Year year) {
+        public void setYear(Optional<Year> year) {
             this.year = year;
         }
 

--- a/src/main/java/seedu/ichifund/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/ichifund/logic/parser/ParserUtil.java
@@ -181,7 +181,7 @@ public class ParserUtil {
      * Parses a {@code String category} into a {@code Category}.
      * Leading and trailing whitespaces will be trimmed.
      *
-     * @throws ParseException if the given {@code address} is invalid.
+     * @throws ParseException if the given {@code category} is invalid.
      */
     public static Category parseCategory(String category) throws ParseException {
         requireNonNull(category);
@@ -191,6 +191,25 @@ public class ParserUtil {
         }
         return new Category(trimmedCategory);
     }
+
+    /**
+     * Parses a {@code String category} into a {@code Category}.
+     * Leading and trailing whitespaces will be trimmed.
+     * Allows for parsing of {@code Category.CATEGORY_ALL}
+     *
+     * @throws ParseException if the given {@code category} is invalid and is not "!all".
+     */
+    public static Category parseCategoryWithAll(String category) throws ParseException {
+        requireNonNull(category);
+        String trimmedCategory = category.trim();
+        if (trimmedCategory.equals(Category.CATEGORY_ALL.toString())) {
+            return Category.CATEGORY_ALL;
+        } else if (!Category.isValidCategory(trimmedCategory)) {
+            throw new ParseException(Category.MESSAGE_CONSTRAINTS);
+        }
+        return new Category(trimmedCategory);
+    }
+
 
     /**
      * Parses a {@code String day} into a {@code Day}.
@@ -247,6 +266,24 @@ public class ParserUtil {
         requireNonNull(transactionType);
         String trimmedTransactionType = transactionType.trim();
         if (!TransactionType.isValidTransactionType(trimmedTransactionType)) {
+            throw new ParseException(TransactionType.MESSAGE_CONSTRAINTS);
+        }
+        return new TransactionType(trimmedTransactionType);
+    }
+
+    /**
+     * Parses a {@code String transactionType} into a {@code TransactionType}.
+     * Leading and trailing whitespaces will be trimmed.
+     * Allows for parsing of {@code TransactionType.TRANSACTION_TYPE_ALL}
+     *
+     * @throws ParseException if the given {@code transactionType} is invalid.
+     */
+    public static TransactionType parseTransactionTypeWithAll(String transactionType) throws ParseException {
+        requireNonNull(transactionType);
+        String trimmedTransactionType = transactionType.trim();
+        if (trimmedTransactionType.equals(TransactionType.TRANSACTION_TYPE_ALL.toString())) {
+            return TransactionType.TRANSACTION_TYPE_ALL;
+        } else if (!TransactionType.isValidTransactionType(trimmedTransactionType)) {
             throw new ParseException(TransactionType.MESSAGE_CONSTRAINTS);
         }
         return new TransactionType(trimmedTransactionType);

--- a/src/main/java/seedu/ichifund/logic/parser/transaction/AddTransactionCommandParser.java
+++ b/src/main/java/seedu/ichifund/logic/parser/transaction/AddTransactionCommandParser.java
@@ -9,6 +9,7 @@ import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_MONTH;
 import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_TRANSACTION_TYPE;
 import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_YEAR;
 
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import seedu.ichifund.logic.commands.transaction.AddTransactionCommand;
@@ -20,12 +21,10 @@ import seedu.ichifund.logic.parser.Prefix;
 import seedu.ichifund.logic.parser.exceptions.ParseException;
 import seedu.ichifund.model.Description;
 import seedu.ichifund.model.amount.Amount;
-import seedu.ichifund.model.date.Date;
 import seedu.ichifund.model.date.Day;
 import seedu.ichifund.model.date.Month;
 import seedu.ichifund.model.date.Year;
 import seedu.ichifund.model.transaction.Category;
-import seedu.ichifund.model.transaction.Transaction;
 import seedu.ichifund.model.transaction.TransactionType;
 
 
@@ -44,8 +43,7 @@ public class AddTransactionCommandParser implements Parser<AddTransactionCommand
                 ArgumentTokenizer.tokenize(args, PREFIX_DESCRIPTION, PREFIX_AMOUNT, PREFIX_CATEGORY, PREFIX_DAY,
                         PREFIX_MONTH, PREFIX_YEAR, PREFIX_TRANSACTION_TYPE);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_DESCRIPTION, PREFIX_AMOUNT, PREFIX_CATEGORY, PREFIX_DAY,
-                PREFIX_MONTH, PREFIX_YEAR, PREFIX_TRANSACTION_TYPE)
+        if (!arePrefixesPresent(argMultimap, PREFIX_DESCRIPTION, PREFIX_AMOUNT)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AddTransactionCommand.MESSAGE_USAGE));
@@ -53,36 +51,106 @@ public class AddTransactionCommandParser implements Parser<AddTransactionCommand
 
         Description description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get());
         Amount amount = ParserUtil.parsePositiveAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
-        Category category = ParserUtil.parseCategory(argMultimap.getValue(PREFIX_CATEGORY).get());
-        Day day = ParserUtil.parseDay(argMultimap.getValue(PREFIX_DAY).get());
-        Month month = ParserUtil.parseMonth(argMultimap.getValue(PREFIX_MONTH).get());
-        Year year = ParserUtil.parseYear(argMultimap.getValue(PREFIX_YEAR).get());
-        TransactionType transactionType = ParserUtil.parseTransactionType(argMultimap
-                .getValue(PREFIX_TRANSACTION_TYPE).get());
+        Optional<Category> category = parseCategory(argMultimap);
+        Optional<Day> day = parseDay(argMultimap);
+        Optional<Month> month = parseMonth(argMultimap);
+        Optional<Year> year = parseYear(argMultimap);
+        Optional<TransactionType> transactionType = parseTransactionType(argMultimap);
 
-        Date date = constructDate(day, month, year);
+        AddTransactionCommand.AddTransactionCommandBuilder builder =
+                new AddTransactionCommand.AddTransactionCommandBuilder();
+        builder.setDescription(description);
+        builder.setAmount(amount);
+        builder.setCategory(category);
+        builder.setDay(day);
+        builder.setMonth(month);
+        builder.setYear(year);
+        builder.setTransactionType(transactionType);
 
-        Transaction transaction = new Transaction(description, amount, category, date, transactionType);
-
-        return new AddTransactionCommand(transaction);
+        return builder.build();
     }
 
     /**
-     * Returns a {@code Date} object from the {@code day}, {@code month} and {@code year}.
+     * Parses the {@code Month} field in an {@code ArgumentMultimap}, if present, into
+     * a {@code Month} object, and wraps it in a {@code Optional} object
+     * Else, an empty {@code Optional} object is returned.
      *
-     * @param day The {@code Day} of the year to be returned.
-     * @param month The {@code Month} of the year to be returned.
-     * @param year The {@code Year} of the year to be returned.
-     * @return A {@code Date} object composed of {@code day}, {@code month} and {@code year}
-     * @throws ParseException If day does not match month and year.
+     * @throws ParseException if the string in {@code argMultimap} is invalid.
      */
-    private static Date constructDate(Day day, Month month, Year year) throws ParseException {
-        if (Date.isValidDate(day, month, year)) {
-            return new Date(day, month, year);
+    private Optional<Day> parseDay(ArgumentMultimap argMultimap) throws ParseException {
+        Optional<String> dayString = argMultimap.getValue(PREFIX_DAY);
+        if (dayString.isEmpty()) {
+            return Optional.empty();
         } else {
-            throw new ParseException(Date.MESSAGE_CONSTRAINTS);
+            return Optional.of(ParserUtil.parseDay(dayString.get()));
         }
     }
+
+    /**
+     * Parses the {@code Month} field in an {@code ArgumentMultimap}, if present, into
+     * a {@code Month} object, and wraps it in a {@code Optional} object
+     * Else, an empty {@code Optional} object is returned.
+     *
+     * @throws ParseException if the string in {@code argMultimap} is invalid.
+     */
+    private Optional<Month> parseMonth(ArgumentMultimap argMultimap) throws ParseException {
+        Optional<String> monthString = argMultimap.getValue(PREFIX_MONTH);
+        if (monthString.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(ParserUtil.parseMonth(monthString.get()));
+        }
+    }
+
+    /**
+     * Parses the {@code Year} field in an {@code ArgumentMultimap}, if present, into
+     * a {@code Year} object, and wraps it in a {@code Optional} object
+     * Else, an empty {@code Optional} object is returned.
+     *
+     * @throws ParseException if the string in {@code argMultimap} is invalid.
+     */
+    private Optional<Year> parseYear(ArgumentMultimap argMultimap) throws ParseException {
+        Optional<String> yearString = argMultimap.getValue(PREFIX_YEAR);
+        if (yearString.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(ParserUtil.parseYear(yearString.get()));
+        }
+    }
+
+    /**
+     * Parses the {@code Category} field in an {@code ArgumentMultimap}, if present, into
+     * a {@code Category} object, and wraps it into an {@code Optional} object.
+     * Else, an empty {@code Optional} object is returned.
+     *
+     * @throws ParseException if the string in {@code argMultimap} is invalid.
+     */
+    private Optional<Category> parseCategory(ArgumentMultimap argMultimap) throws ParseException {
+        Optional<String> categoryString = argMultimap.getValue(PREFIX_CATEGORY);
+        if (categoryString.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(ParserUtil.parseCategory(categoryString.get()));
+        }
+    }
+
+    /**
+     * Parses the {@code TransactionType} field in an {@code ArgumentMultimap}, if present, into
+     * a {@code TransactionType} object, and wraps it into an {@code Optional} object.
+     * Else, an empty {@code Optional} object is returned.
+     *
+     * @throws ParseException if the string in {@code argMultimap} is invalid.
+     */
+    private Optional<TransactionType> parseTransactionType(ArgumentMultimap argMultimap) throws ParseException {
+        Optional<String> typeString = argMultimap.getValue(PREFIX_TRANSACTION_TYPE);
+        if (typeString.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(ParserUtil.parseTransactionType(typeString.get()));
+        }
+    }
+
+
 
     /**
      * Returns true if none of the prefixes contains empty {@code Optional} values in the given

--- a/src/main/java/seedu/ichifund/logic/parser/transaction/FilterTransactionCommandParser.java
+++ b/src/main/java/seedu/ichifund/logic/parser/transaction/FilterTransactionCommandParser.java
@@ -38,7 +38,13 @@ public class FilterTransactionCommandParser implements Parser<FilterTransactionC
         Year year = ParserUtil.parseYear(argMultimap.getValue(PREFIX_YEAR).get());
         Optional<Category> category = argMultimap
                 .getValue(PREFIX_CATEGORY)
-                .flatMap(categoryString -> Optional.of(new Category(categoryString)));
+                .flatMap(categoryString -> {
+                    if (categoryString.equals(Category.CATEGORY_ALL.toString())) {
+                        return Optional.of(Category.CATEGORY_ALL);
+                    } else {
+                        return Optional.of(new Category(categoryString));
+                    }
+                });
 
         return new FilterTransactionCommand(month, year, category);
     }

--- a/src/main/java/seedu/ichifund/logic/parser/transaction/FilterTransactionCommandParser.java
+++ b/src/main/java/seedu/ichifund/logic/parser/transaction/FilterTransactionCommandParser.java
@@ -44,7 +44,11 @@ public class FilterTransactionCommandParser implements Parser<FilterTransactionC
         return buildCommand(month, year, category, transactionType);
     }
 
-    private FilterTransactionCommand buildCommand(Optional<Month> month, Optional<Year> year, Optional<Category> category,
+    /**
+     * Builds the FilterTransactionCommand from data fields.
+     */
+    private FilterTransactionCommand buildCommand(Optional<Month> month, Optional<Year> year,
+                                                  Optional<Category> category,
                                                   Optional<TransactionType> transactionType) {
         FilterTransactionCommand.FilterTransactionCommandBuilder builder =
                 new FilterTransactionCommand.FilterTransactionCommandBuilder();
@@ -57,6 +61,13 @@ public class FilterTransactionCommandParser implements Parser<FilterTransactionC
         return builder.build();
     }
 
+    /**
+     * Parses the {@code Month} field in an {@code ArgumentMultimap}, if present, into
+     * a {@code Month} object, and wraps it in a {@code Optional} object
+     * Else, an empty {@code Optional} object is returned.
+     *
+     * @throws ParseException if the string in {@code argMultimap} is invalid.
+     */
     private Optional<Month> parseMonth(ArgumentMultimap argMultimap) throws ParseException {
         Optional<String> monthString = argMultimap.getValue(PREFIX_MONTH);
         if (monthString.isEmpty()) {
@@ -66,6 +77,13 @@ public class FilterTransactionCommandParser implements Parser<FilterTransactionC
         }
     }
 
+    /**
+     * Parses the {@code Year} field in an {@code ArgumentMultimap}, if present, into
+     * a {@code Year} object, and wraps it in a {@code Optional} object
+     * Else, an empty {@code Optional} object is returned.
+     *
+     * @throws ParseException if the string in {@code argMultimap} is invalid.
+     */
     private Optional<Year> parseYear(ArgumentMultimap argMultimap) throws ParseException {
         Optional<String> yearString = argMultimap.getValue(PREFIX_YEAR);
         if (yearString.isEmpty()) {
@@ -75,6 +93,14 @@ public class FilterTransactionCommandParser implements Parser<FilterTransactionC
         }
     }
 
+    /**
+     * Parses the {@code Category} field in an {@code ArgumentMultimap}, if present, into
+     * a {@code Category} object, including a {@code Category.CATEGORY_ALL} object, and wraps
+     * it into an {@code Optional} object.
+     * Else, an empty {@code Optional} object is returned.
+     *
+     * @throws ParseException if the string in {@code argMultimap} is invalid.
+     */
     private Optional<Category> parseCategory(ArgumentMultimap argMultimap) throws ParseException {
         Optional<String> categoryString = argMultimap.getValue(PREFIX_CATEGORY);
         if (categoryString.isEmpty()) {
@@ -84,6 +110,14 @@ public class FilterTransactionCommandParser implements Parser<FilterTransactionC
         }
     }
 
+    /**
+     * Parses the {@code TransactionType} field in an {@code ArgumentMultimap}, if present, into
+     * a {@code TransactionType} object, including a {@code TransactionType.TRANSACTION_TYPE_ALL} object, and wraps
+     * it into an {@code Optional} object.
+     * Else, an empty {@code Optional} object is returned.
+     *
+     * @throws ParseException if the string in {@code argMultimap} is invalid.
+     */
     private Optional<TransactionType> parseType(ArgumentMultimap argMultimap) throws ParseException {
         Optional<String> typeString = argMultimap.getValue(PREFIX_TRANSACTION_TYPE);
         if (typeString.isEmpty()) {

--- a/src/main/java/seedu/ichifund/logic/parser/transaction/FilterTransactionCommandParser.java
+++ b/src/main/java/seedu/ichifund/logic/parser/transaction/FilterTransactionCommandParser.java
@@ -3,6 +3,7 @@ package seedu.ichifund.logic.parser.transaction;
 import static seedu.ichifund.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_MONTH;
+import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_TRANSACTION_TYPE;
 import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_YEAR;
 
 import java.util.Optional;
@@ -18,6 +19,7 @@ import seedu.ichifund.logic.parser.exceptions.ParseException;
 import seedu.ichifund.model.date.Month;
 import seedu.ichifund.model.date.Year;
 import seedu.ichifund.model.transaction.Category;
+import seedu.ichifund.model.transaction.TransactionType;
 
 /**
  * Parses input arguments and creates a new FilterTransactionCommand object.
@@ -26,7 +28,7 @@ public class FilterTransactionCommandParser implements Parser<FilterTransactionC
     @Override
     public FilterTransactionCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_CATEGORY, PREFIX_MONTH, PREFIX_YEAR);
+                ArgumentTokenizer.tokenize(args, PREFIX_CATEGORY, PREFIX_MONTH, PREFIX_YEAR, PREFIX_TRANSACTION_TYPE);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_MONTH, PREFIX_YEAR)
                 || !argMultimap.getPreamble().isEmpty()) {
@@ -36,7 +38,27 @@ public class FilterTransactionCommandParser implements Parser<FilterTransactionC
 
         Month month = ParserUtil.parseMonth(argMultimap.getValue(PREFIX_MONTH).get());
         Year year = ParserUtil.parseYear(argMultimap.getValue(PREFIX_YEAR).get());
-        Optional<Category> category = argMultimap
+        Optional<Category> category = parseCategory(argMultimap);
+        Optional<TransactionType> transactionType = parseType(argMultimap);
+
+        return buildCommand(month, year, category, transactionType);
+    }
+
+    private FilterTransactionCommand buildCommand(Month month, Year year, Optional<Category> category,
+                                                  Optional<TransactionType> transactionType) {
+        FilterTransactionCommand.FilterTransactionCommandBuilder builder =
+                new FilterTransactionCommand.FilterTransactionCommandBuilder();
+
+        builder.setMonth(month);
+        builder.setYear(year);
+        builder.setCategory(category);
+        builder.setType(transactionType);
+
+        return builder.build();
+    }
+
+    private Optional<Category> parseCategory(ArgumentMultimap argMultimap) {
+        return argMultimap
                 .getValue(PREFIX_CATEGORY)
                 .flatMap(categoryString -> {
                     if (categoryString.equals(Category.CATEGORY_ALL.toString())) {
@@ -46,7 +68,18 @@ public class FilterTransactionCommandParser implements Parser<FilterTransactionC
                     }
                 });
 
-        return new FilterTransactionCommand(month, year, category);
+    }
+
+    private Optional<TransactionType> parseType(ArgumentMultimap argMultimap) {
+        return argMultimap
+                .getValue(PREFIX_TRANSACTION_TYPE)
+                .flatMap(typeString -> {
+                    if (typeString.equals(TransactionType.TRANSACTION_TYPE_ALL.toString())) {
+                        return Optional.of(TransactionType.TRANSACTION_TYPE_ALL);
+                    } else {
+                        return Optional.of(new TransactionType(typeString));
+                    }
+                });
     }
 
     /**

--- a/src/main/java/seedu/ichifund/model/Model.java
+++ b/src/main/java/seedu/ichifund/model/Model.java
@@ -112,12 +112,6 @@ public interface Model {
     /** Returns an unmodifiable view of the filtered transaction list */
     ObservableList<Transaction> getFilteredTransactionList();
 
-    /**
-     * Updates the filter of the filtered transaction list to filter by the given {@code predicate}.
-     * @throws NullPointerException if {@code predicate} is null.
-     */
-    void updateFilteredTransactionList(Predicate<Transaction> predicate);
-
     TransactionContext getTransactionContext();
 
     void setTransactionContext(TransactionContext transactionContext);

--- a/src/main/java/seedu/ichifund/model/Model.java
+++ b/src/main/java/seedu/ichifund/model/Model.java
@@ -17,7 +17,6 @@ import seedu.ichifund.model.transaction.Transaction;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
-    Predicate<Transaction> PREDICATE_SHOW_ALL_TRANSACTIONS = unused -> true;
     Predicate<Repeater> PREDICATE_SHOW_ALL_REPEATERS = unused -> true;
     Predicate<Budget> PREDICATE_SHOW_ALL_BUDGETS = unused -> true;
 
@@ -93,7 +92,7 @@ public interface Model {
     void updateFilteredPersonList(Predicate<Person> predicate);
 
     /**
-     * Adds the given transaction.
+     * Adds the given transaction. Changes the view of the list to show the new transaction.
      */
     void addTransaction(Transaction transaction);
 

--- a/src/main/java/seedu/ichifund/model/ModelManager.java
+++ b/src/main/java/seedu/ichifund/model/ModelManager.java
@@ -229,8 +229,11 @@ public class ModelManager implements Model {
         updateFilteredTransactionList(transactionContext.getPredicate());
     }
 
-    @Override
-    public void updateFilteredTransactionList(Predicate<Transaction> predicate) {
+    /**
+     * Updates the filter of the filtered transaction list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    private void updateFilteredTransactionList(Predicate<Transaction> predicate) {
         requireNonNull(predicate);
         filteredTransactions.setPredicate(predicate);
     }

--- a/src/main/java/seedu/ichifund/model/ModelManager.java
+++ b/src/main/java/seedu/ichifund/model/ModelManager.java
@@ -134,7 +134,8 @@ public class ModelManager implements Model {
     @Override
     public void addTransaction(Transaction transaction) {
         fundBook.addTransaction(transaction);
-        updateFilteredTransactionList(PREDICATE_SHOW_ALL_TRANSACTIONS);
+        TransactionContext newContext = transactionContext.getAccommodatingContext(transaction);
+        setTransactionContext(newContext);
     }
 
     @Override

--- a/src/main/java/seedu/ichifund/model/ModelManager.java
+++ b/src/main/java/seedu/ichifund/model/ModelManager.java
@@ -211,7 +211,7 @@ public class ModelManager implements Model {
 
 
 
-    //=========== Filtered Repeater List Accessors =============================================================
+    //=========== Filtered Transaction List Accessors =============================================================
 
     @Override
     public ObservableList<Transaction> getFilteredTransactionList() {

--- a/src/main/java/seedu/ichifund/model/context/Context.java
+++ b/src/main/java/seedu/ichifund/model/context/Context.java
@@ -8,5 +8,12 @@ import java.util.function.Predicate;
  * @param <T> Class of items to be filtered.
  */
 public interface Context<T> {
+    /** Returns a predicate corresponding to the context. */
     Predicate<T> getPredicate();
+
+    /** Returns a suitably modified context that shows the given object.
+     * 
+     * @param object Object to be accommodated.
+     */
+    Context<T> getAccommodatingContext(T object);
 }

--- a/src/main/java/seedu/ichifund/model/context/Context.java
+++ b/src/main/java/seedu/ichifund/model/context/Context.java
@@ -12,7 +12,7 @@ public interface Context<T> {
     Predicate<T> getPredicate();
 
     /** Returns a suitably modified context that shows the given object.
-     * 
+     *
      * @param object Object to be accommodated.
      */
     Context<T> getAccommodatingContext(T object);

--- a/src/main/java/seedu/ichifund/model/context/TransactionContext.java
+++ b/src/main/java/seedu/ichifund/model/context/TransactionContext.java
@@ -56,12 +56,20 @@ public class TransactionContext implements Context<Transaction> {
         return year;
     }
 
-    public TransactionContext withMonth(Month month) {
-        return new TransactionContext(month, this.year, this.category, this.transactionType);
+    public TransactionContext withMonth(Optional<Month> month) {
+        if (month.isEmpty()) {
+            return this;
+        } else {
+            return new TransactionContext(month.get(), this.year, this.category, this.transactionType);
+        }
     }
 
-    public TransactionContext withYear(Year year) {
-        return new TransactionContext(this.month, year, this.category, this.transactionType);
+    public TransactionContext withYear(Optional<Year> year) {
+        if (year.isEmpty()) {
+            return this;
+        } else {
+            return new TransactionContext(this.month, year.get(), this.category, this.transactionType);
+        }
     }
 
     public TransactionContext withCategory(Optional<Category> category) {

--- a/src/main/java/seedu/ichifund/model/context/TransactionContext.java
+++ b/src/main/java/seedu/ichifund/model/context/TransactionContext.java
@@ -124,6 +124,16 @@ public class TransactionContext implements Context<Transaction> {
         }
     }
 
+    private boolean categoryMatches(Transaction transaction) {
+        return category.isEmpty()
+                || category.get().equals(transaction.getCategory());
+    }
+
+    private boolean transactionTypeMatches(Transaction transaction) {
+        return transactionType.isEmpty()
+                || transactionType.get().equals(transaction.getTransactionType());
+    }
+
     @Override
     public Predicate<Transaction> getPredicate() {
         Predicate<Transaction> predicate = new TransactionDatePredicate(month, year);
@@ -138,6 +148,26 @@ public class TransactionContext implements Context<Transaction> {
         }
 
         return predicate;
+    }
+
+    @Override
+    public TransactionContext getAccommodatingContext(Transaction transaction) {
+        Optional<Category> category = this.category;
+        Optional<TransactionType> transactionType = this.transactionType;
+
+        if (!categoryMatches(transaction)) {
+            category = Optional.empty();
+        }
+
+        if (!transactionTypeMatches(transaction)) {
+            transactionType = Optional.empty();
+        }
+
+        return new TransactionContext(
+                transaction.getDate().getMonth(),
+                transaction.getDate().getYear(),
+                category,
+                transactionType);
     }
 
     @Override

--- a/src/main/java/seedu/ichifund/model/context/TransactionContext.java
+++ b/src/main/java/seedu/ichifund/model/context/TransactionContext.java
@@ -48,6 +48,22 @@ public class TransactionContext implements Context<Transaction> {
         this.transactionType = transactionType;
     }
 
+    public boolean hasCategory() {
+        return category.isPresent();
+    }
+
+    public boolean hasTransactionType() {
+        return transactionType.isPresent();
+    }
+
+    public Category getCategory() {
+        return category.orElse(Category.CATEGORY_DEFAULT);
+    }
+
+    public TransactionType getTransactionType() {
+        return transactionType.orElse(TransactionType.TRANSACTION_TYPE_DEFAULT);
+    }
+
     public Month getMonth() {
         return month;
     }

--- a/src/main/java/seedu/ichifund/model/context/TransactionContext.java
+++ b/src/main/java/seedu/ichifund/model/context/TransactionContext.java
@@ -75,10 +75,12 @@ public class TransactionContext implements Context<Transaction> {
     @Override
     public Predicate<Transaction> getPredicate() {
         Predicate<Transaction> datePredicate = new TransactionDatePredicate(month, year);
-        if (category.isPresent()) {
-            return datePredicate.and(new TransactionCategoryPredicate(category.get()));
-        } else {
+        if (!category.isPresent()) {
             return datePredicate;
+        } else if (category.get() == Category.CATEGORY_ALL) {
+            return datePredicate;
+        } else {
+            return datePredicate.and(new TransactionCategoryPredicate(category.get()));
         }
     }
 

--- a/src/main/java/seedu/ichifund/model/context/TransactionContext.java
+++ b/src/main/java/seedu/ichifund/model/context/TransactionContext.java
@@ -10,6 +10,8 @@ import seedu.ichifund.model.transaction.Category;
 import seedu.ichifund.model.transaction.Transaction;
 import seedu.ichifund.model.transaction.TransactionCategoryPredicate;
 import seedu.ichifund.model.transaction.TransactionDatePredicate;
+import seedu.ichifund.model.transaction.TransactionType;
+import seedu.ichifund.model.transaction.TransactionTypePredicate;
 
 /**
  * Unmodifiable context for filtering a list of transactions.
@@ -19,6 +21,7 @@ public class TransactionContext implements Context<Transaction> {
     private final Month month;
     private final Year year;
     private final Optional<Category> category;
+    private final Optional<TransactionType> transactionType;
 
     /**
      * Public constructor for initialization of context.
@@ -34,18 +37,15 @@ public class TransactionContext implements Context<Transaction> {
         }
 
         this.category = Optional.empty();
+        this.transactionType = Optional.empty();
     }
 
-    private TransactionContext(Month month, Year year) {
-        this.month = month;
-        this.year = year;
-        this.category = Optional.empty();
-    }
-
-    private TransactionContext(Month month, Year year, Optional<Category> category) {
+    private TransactionContext(Month month, Year year, Optional<Category> category,
+                               Optional<TransactionType> transactionType) {
         this.month = month;
         this.year = year;
         this.category = category;
+        this.transactionType = transactionType;
     }
 
     public Month getMonth() {
@@ -56,32 +56,48 @@ public class TransactionContext implements Context<Transaction> {
         return year;
     }
 
-    public TransactionContext getUpdatedContext(Month month) {
-        return new TransactionContext(month, this.year, this.category);
+    public TransactionContext withMonth(Month month) {
+        return new TransactionContext(month, this.year, this.category, this.transactionType);
     }
 
-    public TransactionContext getUpdatedContext(Year year) {
-        return new TransactionContext(this.month, year, this.category);
+    public TransactionContext withYear(Year year) {
+        return new TransactionContext(this.month, year, this.category, this.transactionType);
     }
 
-    public TransactionContext getUpdatedContext(Optional<Category> category) {
-        return new TransactionContext(this.month, this.year, category);
+    public TransactionContext withCategory(Optional<Category> category) {
+        if (category.isEmpty()) {
+            return this;
+        } else if (category.get() == Category.CATEGORY_ALL) {
+            return new TransactionContext(this.month, this.year, Optional.empty(), this.transactionType);
+        } else {
+            return new TransactionContext(this.month, this.year, category, this.transactionType);
+        }
     }
 
-    public TransactionContext getContextWithAllCategories() {
-        return new TransactionContext(this.month, this.year);
+    public TransactionContext withType(Optional<TransactionType> transactionType) {
+        if (transactionType.isEmpty()) {
+            return this;
+        } else if (transactionType.get() == TransactionType.TRANSACTION_TYPE_ALL) {
+            return new TransactionContext(this.month, this.year, this.category, Optional.empty());
+        } else {
+            return new TransactionContext(this.month, this.year, this.category, transactionType);
+        }
     }
 
     @Override
     public Predicate<Transaction> getPredicate() {
-        Predicate<Transaction> datePredicate = new TransactionDatePredicate(month, year);
-        if (!category.isPresent()) {
-            return datePredicate;
-        } else if (category.get() == Category.CATEGORY_ALL) {
-            return datePredicate;
-        } else {
-            return datePredicate.and(new TransactionCategoryPredicate(category.get()));
+        Predicate<Transaction> predicate = new TransactionDatePredicate(month, year);
+        if (category.isPresent() && category.get() != Category.CATEGORY_ALL) {
+            predicate = predicate
+                    .and(new TransactionCategoryPredicate(category.get()));
         }
+
+        if (transactionType.isPresent() && transactionType.get() != TransactionType.TRANSACTION_TYPE_ALL) {
+            predicate = predicate
+                    .and(new TransactionTypePredicate(transactionType.get()));
+        }
+
+        return predicate;
     }
 
     @Override

--- a/src/main/java/seedu/ichifund/model/context/TransactionContext.java
+++ b/src/main/java/seedu/ichifund/model/context/TransactionContext.java
@@ -56,6 +56,10 @@ public class TransactionContext implements Context<Transaction> {
         return year;
     }
 
+    /**
+     * Returns a new {@code TransitionContext} updated with the input month.
+     * Returns the same object if there is no month.
+     */
     public TransactionContext withMonth(Optional<Month> month) {
         if (month.isEmpty()) {
             return this;
@@ -64,6 +68,10 @@ public class TransactionContext implements Context<Transaction> {
         }
     }
 
+    /**
+     * Returns a new {@code TransitionContext} updated with the input year.
+     * Returns the same object if there is no year.
+     */
     public TransactionContext withYear(Optional<Year> year) {
         if (year.isEmpty()) {
             return this;
@@ -72,6 +80,10 @@ public class TransactionContext implements Context<Transaction> {
         }
     }
 
+    /**
+     * Returns a new {@code TransitionContext} updated with the input category.
+     * Returns the same object if there is no category.
+     */
     public TransactionContext withCategory(Optional<Category> category) {
         if (category.isEmpty()) {
             return this;
@@ -82,6 +94,10 @@ public class TransactionContext implements Context<Transaction> {
         }
     }
 
+    /**
+     * Returns a new {@code TransitionContext} updated with the input transaction type.
+     * Returns the same object if there is no transaction type.
+     */
     public TransactionContext withType(Optional<TransactionType> transactionType) {
         if (transactionType.isEmpty()) {
             return this;

--- a/src/main/java/seedu/ichifund/model/date/Day.java
+++ b/src/main/java/seedu/ichifund/model/date/Day.java
@@ -3,6 +3,8 @@ package seedu.ichifund.model.date;
 import static java.util.Objects.requireNonNull;
 import static seedu.ichifund.commons.util.AppUtil.checkArgument;
 
+import java.time.LocalDate;
+
 /**
  * Represents a Day in a Date in IchiFund.
  * Guarantees: details are present and not null, field values are validated, immutable.
@@ -34,6 +36,10 @@ public class Day implements Comparable<Day> {
      */
     public static boolean isValidDay(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    public static Day getCurrent() {
+        return new Day(Integer.toString(LocalDate.now().getDayOfMonth()));
     }
 
     @Override

--- a/src/main/java/seedu/ichifund/model/transaction/Category.java
+++ b/src/main/java/seedu/ichifund/model/transaction/Category.java
@@ -17,8 +17,13 @@ public class Category {
      * otherwise " " (a blank string) becomes a valid input.
      */
     public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final Category CATEGORY_ALL = new Category();
 
     public final String category;
+
+    private Category() {
+        this.category = "!all";
+    }
 
     /**
      * Constructs a {@code Category}.

--- a/src/main/java/seedu/ichifund/model/transaction/Category.java
+++ b/src/main/java/seedu/ichifund/model/transaction/Category.java
@@ -18,6 +18,7 @@ public class Category {
      */
     public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
     public static final Category CATEGORY_ALL = new Category();
+    public static final Category CATEGORY_DEFAULT = new Category("Uncategorised");
 
     public final String category;
 

--- a/src/main/java/seedu/ichifund/model/transaction/TransactionType.java
+++ b/src/main/java/seedu/ichifund/model/transaction/TransactionType.java
@@ -17,8 +17,13 @@ public class TransactionType {
      * otherwise " " (a blank string) becomes a valid input.
      */
     public static final String VALIDATION_REGEX = "in|exp";
+    public static final TransactionType TRANSACTION_TYPE_ALL = new TransactionType();
 
     public final String transactionType;
+
+    private TransactionType() {
+        this.transactionType = "!all";
+    }
 
     /**
      * Constructs a {@code Category}.

--- a/src/main/java/seedu/ichifund/model/transaction/TransactionType.java
+++ b/src/main/java/seedu/ichifund/model/transaction/TransactionType.java
@@ -18,6 +18,7 @@ public class TransactionType {
      */
     public static final String VALIDATION_REGEX = "in|exp";
     public static final TransactionType TRANSACTION_TYPE_ALL = new TransactionType();
+    public static final TransactionType TRANSACTION_TYPE_DEFAULT = new TransactionType("exp");
 
     public final String transactionType;
 

--- a/src/main/java/seedu/ichifund/model/transaction/TransactionTypePredicate.java
+++ b/src/main/java/seedu/ichifund/model/transaction/TransactionTypePredicate.java
@@ -2,6 +2,9 @@ package seedu.ichifund.model.transaction;
 
 import java.util.function.Predicate;
 
+/**
+ * Tests that a {@code Transaction}'s {@code TransactionType} matches the given transaction type.
+ */
 public class TransactionTypePredicate implements Predicate<Transaction> {
     private final TransactionType transactionType;
 

--- a/src/main/java/seedu/ichifund/model/transaction/TransactionTypePredicate.java
+++ b/src/main/java/seedu/ichifund/model/transaction/TransactionTypePredicate.java
@@ -1,0 +1,16 @@
+package seedu.ichifund.model.transaction;
+
+import java.util.function.Predicate;
+
+public class TransactionTypePredicate implements Predicate<Transaction> {
+    private final TransactionType transactionType;
+
+    public TransactionTypePredicate(TransactionType transactionType) {
+        this.transactionType = transactionType;
+    }
+
+    @Override
+    public boolean test(Transaction transaction) {
+        return transaction.getTransactionType().equals(transactionType);
+    }
+}

--- a/src/test/java/seedu/ichifund/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/ichifund/logic/commands/AddCommandTest.java
@@ -163,11 +163,6 @@ public class AddCommandTest {
         }
 
         @Override
-        public void updateFilteredTransactionList(Predicate<Transaction> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
         public TransactionContext getTransactionContext() {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
Fixes #120 , closes #121 , resolves #122 

**Notes on how to apply this other components**

Level 1:
1) Implement appropriate `Context` (can skip `getAccommodatedContext` first)
1) Replace `updateFilteredList` in `ModelManager` and `Model` with `setContext`
1) Implement initialization of context in `ModelManager`
1) Implement basic filtering functions (directly constructs new `Context`)

Level 2:
1) Implement methods to get an updated context (e.g. `withCategory`, mutability is up to you, but I prefer not to do that)
1) Implement optional arguments for `Context` and for filtering using above methods

Level 3:
1) Implement methods to infer unspecified fields for adding (e.g. `getCategory`, may need to define defaults)
1) Implement optional arguments for relevant `AddCommand`

Level 4:
1) Implement `getAccommodatedContext` in `Context`
1) Change `addObject` in `ModelManager` to use `setContext` and `getAccommodatedContext`
1) (Not done yet) Change `setObject` as above.

N.B. Should wait for testing to be completed before adapting my code.