### PR TITLE
Support computation of spending in budget

### DIFF
--- a/src/main/java/seedu/ichifund/MainApp.java
+++ b/src/main/java/seedu/ichifund/MainApp.java
@@ -64,6 +64,7 @@ public class MainApp extends Application {
         model = initModelManager(storage, userPrefs);
 
         logic = new LogicManager(model, storage);
+        logic.executeAllTasks();
 
         ui = new UiManager(logic);
     }

--- a/src/main/java/seedu/ichifund/logic/Logic.java
+++ b/src/main/java/seedu/ichifund/logic/Logic.java
@@ -26,6 +26,11 @@ public interface Logic {
     CommandResult execute(String commandText) throws CommandException, ParseException;
 
     /**
+     * Executes all the tasks.
+     */
+    void executeAllTasks();
+
+    /**
      * Returns the FundBook.
      *
      * @see seedu.ichifund.model.Model#getFundBook()

--- a/src/main/java/seedu/ichifund/logic/LogicManager.java
+++ b/src/main/java/seedu/ichifund/logic/LogicManager.java
@@ -12,6 +12,7 @@ import seedu.ichifund.logic.commands.CommandResult;
 import seedu.ichifund.logic.commands.exceptions.CommandException;
 import seedu.ichifund.logic.parser.IchiFundParser;
 import seedu.ichifund.logic.parser.exceptions.ParseException;
+import seedu.ichifund.logic.tasks.TaskManager;
 import seedu.ichifund.model.Model;
 import seedu.ichifund.model.ReadOnlyFundBook;
 import seedu.ichifund.model.budget.Budget;
@@ -29,11 +30,13 @@ public class LogicManager implements Logic {
     private final Model model;
     private final Storage storage;
     private final IchiFundParser ichiFundParser;
+    private final TaskManager taskManager;
 
     public LogicManager(Model model, Storage storage) {
         this.model = model;
         this.storage = storage;
         ichiFundParser = new IchiFundParser();
+        taskManager = new TaskManager();
     }
 
     @Override
@@ -43,6 +46,7 @@ public class LogicManager implements Logic {
         CommandResult commandResult;
         Command command = ichiFundParser.parseCommand(commandText);
         commandResult = command.execute(model);
+        taskManager.executeAll(model);
 
         try {
             storage.saveFundBook(model.getFundBook());
@@ -51,6 +55,11 @@ public class LogicManager implements Logic {
         }
 
         return commandResult;
+    }
+
+    @Override
+    public void executeAllTasks() {
+        taskManager.executeAll(model);
     }
 
     @Override

--- a/src/main/java/seedu/ichifund/logic/commands/budget/AddBudgetCommand.java
+++ b/src/main/java/seedu/ichifund/logic/commands/budget/AddBudgetCommand.java
@@ -2,7 +2,10 @@ package seedu.ichifund.logic.commands.budget;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_MONTH;
+import static seedu.ichifund.logic.parser.CliSyntax.PREFIX_YEAR;
 
 import seedu.ichifund.logic.commands.Command;
 import seedu.ichifund.logic.commands.CommandResult;
@@ -17,11 +20,15 @@ public class AddBudgetCommand extends Command {
 
     public static final String COMMAND_WORD = "badd";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a budget to IchiFund. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a budget to IchiFund.\n"
             + "Parameters: "
             + PREFIX_DESCRIPTION + "DESCRIPTION "
-            + PREFIX_AMOUNT + "AMOUNT\n"
-            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_AMOUNT + "AMOUNT "
+            + "[" + PREFIX_CATEGORY + "CATEGORY] "
+            + "[" + PREFIX_MONTH + "MONTH "
+            + PREFIX_YEAR + "YEAR]\n"
+            + "Example: "
+            + COMMAND_WORD + " "
             + PREFIX_DESCRIPTION + "Saving for my future "
             + PREFIX_AMOUNT + "200.00";
 

--- a/src/main/java/seedu/ichifund/logic/tasks/Task.java
+++ b/src/main/java/seedu/ichifund/logic/tasks/Task.java
@@ -1,0 +1,23 @@
+package seedu.ichifund.logic.tasks;
+
+import seedu.ichifund.model.Model;
+
+/**
+ * Represents a task with hidden internal logic and the ability to be executed.
+ *
+ * Note that {@code Task} is different from {@code Command} in that task are not
+ * immediately triggered by user interaction.
+ *
+ * For instance, when a transaction is added, a task would be triggered to refresh
+ * the budget information.
+ */
+public abstract class Task {
+
+    /**
+     * Executes the task.
+     *
+     * @param model {@code Model} which the task should operate on.
+     */
+    public abstract void execute(Model model);
+
+}

--- a/src/main/java/seedu/ichifund/logic/tasks/TaskManager.java
+++ b/src/main/java/seedu/ichifund/logic/tasks/TaskManager.java
@@ -1,0 +1,25 @@
+package seedu.ichifund.logic.tasks;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import seedu.ichifund.logic.tasks.budget.ComputeBudgetTask;
+import seedu.ichifund.model.Model;
+
+/**
+ * Manages all the task to be executed.
+ */
+public class TaskManager {
+
+    private final List<Task> tasks;
+
+    public TaskManager() {
+        tasks = new ArrayList<>();
+        tasks.add(new ComputeBudgetTask());
+    }
+
+    public void executeAll(Model model) {
+        tasks.forEach(task -> task.execute(model));
+    }
+
+}

--- a/src/main/java/seedu/ichifund/logic/tasks/budget/ComputeBudgetTask.java
+++ b/src/main/java/seedu/ichifund/logic/tasks/budget/ComputeBudgetTask.java
@@ -38,7 +38,7 @@ public class ComputeBudgetTask extends Task {
      * @return A predicate according to the budget criteria.
      */
     private Predicate<Transaction> createPredicateForBudget(Budget budget) {
-        Predicate<Transaction> predicate = transaction -> true;
+        Predicate<Transaction> predicate = Transaction::isExpenditure;
         if (budget.getCategory() != null) {
             predicate = predicate.and(transaction -> transaction.isIn(budget.getCategory()));
         }

--- a/src/main/java/seedu/ichifund/logic/tasks/budget/ComputeBudgetTask.java
+++ b/src/main/java/seedu/ichifund/logic/tasks/budget/ComputeBudgetTask.java
@@ -1,0 +1,52 @@
+package seedu.ichifund.logic.tasks.budget;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import javafx.collections.ObservableList;
+import seedu.ichifund.logic.tasks.Task;
+import seedu.ichifund.model.Model;
+import seedu.ichifund.model.amount.Amount;
+import seedu.ichifund.model.budget.Budget;
+import seedu.ichifund.model.budget.ComputedBudget;
+import seedu.ichifund.model.transaction.Transaction;
+
+/**
+ * Compute all the budget spending.
+ */
+public class ComputeBudgetTask extends Task {
+
+    @Override
+    public void execute(Model model) {
+        ObservableList<Budget> budgetList = model.getFundBook().getBudgetList();
+        for (Budget budget : budgetList) {
+            List<Amount> filteredAmounts = model.getFundBook().getTransactionList()
+                    .filtered(createPredicateForBudget(budget))
+                    .stream()
+                    .map(Transaction::getAmount)
+                    .collect(Collectors.toList());
+            Amount spending = Amount.addAll(filteredAmounts);
+            model.setBudget(budget, new ComputedBudget(budget, spending));
+        }
+    }
+
+    /***
+     * Create a predicate according to the criteria set within the budget.
+     *
+     * @param budget The budget that will serve as a context to create the predicate.
+     * @return A predicate according to the budget criteria.
+     */
+    private Predicate<Transaction> createPredicateForBudget(Budget budget) {
+        Predicate<Transaction> predicate = transaction -> true;
+        if (budget.getCategory() != null) {
+            predicate = predicate.and(transaction -> transaction.isIn(budget.getCategory()));
+        }
+        if (budget.getMonth() != null && budget.getYear() != null) {
+            predicate = predicate.and(transaction -> transaction.isIn(budget.getMonth()));
+            predicate = predicate.and(transaction -> transaction.isIn(budget.getYear()));
+        }
+        return predicate;
+    }
+
+}

--- a/src/main/java/seedu/ichifund/model/budget/ComputedBudget.java
+++ b/src/main/java/seedu/ichifund/model/budget/ComputedBudget.java
@@ -1,0 +1,78 @@
+package seedu.ichifund.model.budget;
+
+import static seedu.ichifund.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Objects;
+
+import seedu.ichifund.model.Description;
+import seedu.ichifund.model.amount.Amount;
+import seedu.ichifund.model.date.Month;
+import seedu.ichifund.model.date.Year;
+import seedu.ichifund.model.transaction.Category;
+
+/**
+ * Represents a Budget that has been computed in the fund book.
+ * Guarantees: details are present and not null, field values are validated, immutable.
+ */
+public class ComputedBudget extends Budget {
+
+    // Identity fields
+    private final Amount spending;
+
+    /**
+     * Description, amount, and spending must be present and not null.
+     */
+    public ComputedBudget(Description description, Amount amount, Month month,
+                          Year year, Category category, Amount spending) {
+        super(description, amount, month, year, category);
+        requireAllNonNull(spending);
+        this.spending = spending;
+    }
+
+    public Amount getSpending() {
+        return spending;
+    }
+
+    /**
+     * Returns true if both budgets have the same description and spending.
+     * This defines a weaker notion of equality between two computed budgets.
+     */
+    public boolean isSameComputedBudget(ComputedBudget otherBudget) {
+        if (otherBudget == this) {
+            return true;
+        }
+
+        return otherBudget != null && otherBudget.isSameBudget(otherBudget)
+                && otherBudget.getSpending().equals(getSpending());
+    }
+
+    /**
+     * Returns true if both budgets have the same identity and data fields.
+     * This defines a stronger notion of equality between two budgets.
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof ComputedBudget)) {
+            return false;
+        }
+
+        ComputedBudget otherBudget = (ComputedBudget) other;
+        return super.equals(otherBudget) && otherBudget.getSpending().equals(getSpending());
+    }
+
+    @Override
+    public int hashCode() {
+        // use this method for custom fields hashing instead of implementing your own
+        return Objects.hash(getDescription(), getAmount(), getMonth(), getYear(), getCategory(), getSpending());
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + " Spending: " + getSpending();
+    }
+
+}

--- a/src/main/java/seedu/ichifund/model/budget/ComputedBudget.java
+++ b/src/main/java/seedu/ichifund/model/budget/ComputedBudget.java
@@ -29,6 +29,13 @@ public class ComputedBudget extends Budget {
         this.spending = spending;
     }
 
+    public ComputedBudget(Budget budget, Amount spending) {
+        super(budget.getDescription(), budget.getAmount(), budget.getMonth(),
+                budget.getYear(), budget.getCategory());
+        requireAllNonNull(spending);
+        this.spending = spending;
+    }
+
     public Amount getSpending() {
         return spending;
     }

--- a/src/main/java/seedu/ichifund/ui/BudgetCard.java
+++ b/src/main/java/seedu/ichifund/ui/BudgetCard.java
@@ -2,8 +2,10 @@ package seedu.ichifund.ui;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
+import javafx.scene.control.ProgressBar;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import seedu.ichifund.model.amount.Amount;
 import seedu.ichifund.model.budget.Budget;
 import seedu.ichifund.model.budget.ComputedBudget;
 
@@ -34,6 +36,8 @@ public class BudgetCard extends UiPart<Region> {
     private Label amount;
     @FXML
     private Label criterion;
+    @FXML
+    private ProgressBar budgetProgress;
 
     public BudgetCard(Budget budget, int displayedIndex) {
         super(FXML);
@@ -43,11 +47,20 @@ public class BudgetCard extends UiPart<Region> {
         criterion.setText(budget.toCriterionString());
 
         if (budget instanceof ComputedBudget) {
-            amount.setText("$" + ((ComputedBudget) budget).getSpending().toString()
-                    + " / $" + budget.getAmount().toString());
+            Amount spending = ((ComputedBudget) budget).getSpending();
+            Amount limit = budget.getAmount();
+            double ratio = (double) spending.valueInCents / limit.valueInCents;
+            amount.setText("$" + spending.toString() + " / $" + limit.toString());
+            budgetProgress.setProgress(ratio);
+            budgetProgress.setStyle("-fx-accent: " + getBarColor(ratio));
         } else {
             amount.setText("$" + budget.getAmount().toString());
+            budgetProgress.setProgress(0.0);
         }
+    }
+
+    private String getBarColor(double ratio) {
+        return ratio > 0.8 ? "#ff7675" : "#00b894";
     }
 
     @Override

--- a/src/main/java/seedu/ichifund/ui/BudgetCard.java
+++ b/src/main/java/seedu/ichifund/ui/BudgetCard.java
@@ -5,6 +5,7 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.ichifund.model.budget.Budget;
+import seedu.ichifund.model.budget.ComputedBudget;
 
 /**
  * An UI component that displays information of a {@code Budget}.
@@ -39,8 +40,14 @@ public class BudgetCard extends UiPart<Region> {
         this.budget = budget;
         id.setText(displayedIndex + ". ");
         description.setText(budget.getDescription().toString());
-        amount.setText(budget.getAmount().toString());
         criterion.setText(budget.toCriterionString());
+
+        if (budget instanceof ComputedBudget) {
+            amount.setText("$" + ((ComputedBudget) budget).getSpending().toString()
+                    + " / $" + budget.getAmount().toString());
+        } else {
+            amount.setText("$" + budget.getAmount().toString());
+        }
     }
 
     @Override

--- a/src/main/resources/view/BudgetListCard.fxml
+++ b/src/main/resources/view/BudgetListCard.fxml
@@ -9,30 +9,37 @@
 
 <?import javafx.scene.control.ProgressBar?>
 
+<?import javafx.scene.layout.ColumnConstraints?>
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <GridPane HBox.hgrow="ALWAYS">
-        <VBox alignment="CENTER_LEFT" minHeight="80" GridPane.columnIndex="0">
-            <HBox spacing="5" alignment="CENTER_LEFT">
-                <Label fx:id="id" styleClass="cell_big_label">
-                    <minWidth>
-                        <!-- Ensures that the label text is never truncated -->
-                        <Region fx:constant="USE_PREF_SIZE" />
-                    </minWidth>
-                </Label>
-                <Label fx:id="description" text="\$description" styleClass="cell_big_label" />
-            </HBox>
-            <Label fx:id="criterion" styleClass="cell_small_label" text="\$criterion" />
-            <VBox>
+        <columnConstraints>
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+        </columnConstraints>
+        <HBox GridPane.columnIndex="0">
+            <VBox alignment="CENTER_LEFT">
+                <HBox alignment="CENTER_LEFT">
+                    <Label fx:id="id" styleClass="cell_big_label">
+                        <minWidth>
+                            <!-- Ensures that the label text is never truncated -->
+                            <Region fx:constant="USE_PREF_SIZE" />
+                        </minWidth>
+                    </Label>
+                    <Label fx:id="description" text="\$description" styleClass="cell_big_label" />
+                </HBox>
+                <Label fx:id="criterion" styleClass="cell_small_label" text="\$criterion" />
+            </VBox>
+            <Region HBox.hgrow="ALWAYS" />
+            <VBox alignment="CENTER_RIGHT">
                 <padding>
                     <Insets top="5" />
                 </padding>
                 <Label fx:id="amount" text="\$amount" />
-                <ProgressBar fx:id="budgetProgress" progress="0" prefWidth="200">
+                <ProgressBar fx:id="budgetProgress" progress="0" prefWidth="200" prefHeight="10">
                     <VBox.margin>
                         <Insets top="5" />
                     </VBox.margin>
                 </ProgressBar>
             </VBox>
-        </VBox>
+        </HBox>
     </GridPane>
 </HBox>

--- a/src/main/resources/view/BudgetListCard.fxml
+++ b/src/main/resources/view/BudgetListCard.fxml
@@ -26,7 +26,9 @@
                 </Label>
                 <Label fx:id="description" text="\$description" styleClass="cell_big_label" />
             </HBox>
-            <Label fx:id="amount" text="\$amount" />
+            <HBox>
+                <Label fx:id="amount" text="\$amount" />
+            </HBox>
             <Label fx:id="criterion" styleClass="cell_small_label" text="\$criterion" />
         </VBox>
     </GridPane>

--- a/src/main/resources/view/BudgetListCard.fxml
+++ b/src/main/resources/view/BudgetListCard.fxml
@@ -8,6 +8,8 @@
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
 
+<?import javafx.scene.control.ProgressBar?>
+
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <GridPane HBox.hgrow="ALWAYS">
         <columnConstraints>
@@ -26,10 +28,18 @@
                 </Label>
                 <Label fx:id="description" text="\$description" styleClass="cell_big_label" />
             </HBox>
-            <HBox>
-                <Label fx:id="amount" text="\$amount" />
-            </HBox>
             <Label fx:id="criterion" styleClass="cell_small_label" text="\$criterion" />
+            <VBox>
+                <padding>
+                    <Insets top="5" />
+                </padding>
+                <Label fx:id="amount" text="\$amount" />
+                <ProgressBar fx:id="budgetProgress" progress="0" prefWidth="200">
+                    <VBox.margin>
+                        <Insets top="5" />
+                    </VBox.margin>
+                </ProgressBar>
+            </VBox>
         </VBox>
     </GridPane>
 </HBox>

--- a/src/main/resources/view/IchiTheme.css
+++ b/src/main/resources/view/IchiTheme.css
@@ -196,10 +196,15 @@
 
 #budgetProgress {
     -fx-accent: #00b894;
-    -fx-margin: 5px;
 }
 
 #budgetProgress .bar {
-    -fx-background-insets: 1 1 2 1;
-    -fx-padding: 3px;
+    -fx-background-insets: 0;
+    -fx-border-radius: 0;
+    -fx-background-radius: 10px;
+}
+
+#budgetProgress .track {
+    -fx-background-insets: 0;
+    -fx-background-color: #cfd8dc;
 }

--- a/src/main/resources/view/IchiTheme.css
+++ b/src/main/resources/view/IchiTheme.css
@@ -180,3 +180,13 @@
 .cell_small_label {
     -fx-font-size: 10px;
 }
+
+#budgetProgress {
+    -fx-accent: #00b894;
+    -fx-margin: 5px;
+}
+
+#budgetProgress .bar {
+    -fx-background-insets: 1 1 2 1;
+    -fx-padding: 3px;
+}


### PR DESCRIPTION
To accomplish this, I have added a new abstraction: `Task` (see 7e10717).

Essentially, `Task`s are different from `Command`s in that they are not necessarily triggered by user. For instance, in this PR, I added a `ComputeBudgetTask` that computes the spendings for each budget. Besides being triggered after each edit of transaction, this is also triggered when the app first starts (see 767e961). 

I'll describe broadly how the task system works.

Upon startup, `LogicManager` would create a new `TaskManager`, which in turns create all the various `Task`s. Whenever needed, one could call `logic.executeAllTasks()` to execute all tasks. This can be seen in 767e961 and line 49 of a33121.