### PR TITLE
Rename parser manager to feature parser

### DIFF
--- a/src/main/java/seedu/ichifund/logic/Logic.java
+++ b/src/main/java/seedu/ichifund/logic/Logic.java
@@ -36,12 +36,12 @@ public interface Logic {
     /**
      * Returns an unmodifiable version of the index of the current parser manager.
      */
-    ObservableValue<Integer> getCurrentParserManagerIndex();
+    ObservableValue<Integer> getCurrentFeatureParserIndex();
 
     /**
      * Sets the current parser manager according to the given index.
      */
-    void setParserManager(int index);
+    void setFeatureParser(int index);
 
     /**
      * Returns the FundBook.

--- a/src/main/java/seedu/ichifund/logic/LogicManager.java
+++ b/src/main/java/seedu/ichifund/logic/LogicManager.java
@@ -66,12 +66,12 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public ObservableValue<Integer> getCurrentParserManagerIndex() {
+    public ObservableValue<Integer> getCurrentFeatureParserIndex() {
         return ichiFundParser.getCurrentParserManagerIndex();
     }
 
     @Override
-    public void setParserManager(int index) {
+    public void setFeatureParser(int index) {
         ichiFundParser.setParserManager(index);
     }
 

--- a/src/main/java/seedu/ichifund/logic/parser/FeatureParser.java
+++ b/src/main/java/seedu/ichifund/logic/parser/FeatureParser.java
@@ -4,9 +4,9 @@ import seedu.ichifund.logic.commands.Command;
 import seedu.ichifund.logic.parser.exceptions.ParseException;
 
 /**
- * Represents a ParserManager that passes user input to the appropriate Parser.
+ * Represents a FeatureParser that passes user input to the appropriate Parser.
  */
-public interface ParserManager {
+public interface FeatureParser {
 
     String getTabSwitchCommandWord();
 

--- a/src/main/java/seedu/ichifund/logic/parser/IchiFundParser.java
+++ b/src/main/java/seedu/ichifund/logic/parser/IchiFundParser.java
@@ -18,12 +18,12 @@ import seedu.ichifund.logic.commands.ExitCommand;
 import seedu.ichifund.logic.commands.FindCommand;
 import seedu.ichifund.logic.commands.HelpCommand;
 import seedu.ichifund.logic.commands.ListCommand;
-import seedu.ichifund.logic.parser.analytics.AnalyticsParserManager;
-import seedu.ichifund.logic.parser.budget.BudgetParserManager;
+import seedu.ichifund.logic.parser.analytics.AnalyticsFeatureParser;
+import seedu.ichifund.logic.parser.budget.BudgetFeatureParser;
 import seedu.ichifund.logic.parser.exceptions.ParseException;
-import seedu.ichifund.logic.parser.loan.LoanParserManager;
-import seedu.ichifund.logic.parser.repeater.RepeaterParserManager;
-import seedu.ichifund.logic.parser.transaction.TransactionParserManager;
+import seedu.ichifund.logic.parser.loan.LoanFeatureParser;
+import seedu.ichifund.logic.parser.repeater.RepeaterFeatureParser;
+import seedu.ichifund.logic.parser.transaction.TransactionFeatureParser;
 
 /**
  * Parses user input.
@@ -35,19 +35,19 @@ public class IchiFundParser {
      */
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
 
-    private final ArrayList<ParserManager> parserManagers;
-    private ParserManager currentParserManager;
+    private final ArrayList<FeatureParser> featureParsers;
+    private FeatureParser currentFeatureParser;
     private SimpleObjectProperty<Integer> currentParserManagerIndex;
 
     public IchiFundParser() {
-        parserManagers = new ArrayList<>();
-        parserManagers.add(new TransactionParserManager());
-        parserManagers.add(new RepeaterParserManager());
-        parserManagers.add(new BudgetParserManager());
-        parserManagers.add(new LoanParserManager());
-        parserManagers.add(new AnalyticsParserManager());
-        currentParserManager = parserManagers.get(0);
-        currentParserManagerIndex = new SimpleObjectProperty<>(currentParserManager.getTabIndex());
+        featureParsers = new ArrayList<>();
+        featureParsers.add(new TransactionFeatureParser());
+        featureParsers.add(new RepeaterFeatureParser());
+        featureParsers.add(new BudgetFeatureParser());
+        featureParsers.add(new LoanFeatureParser());
+        featureParsers.add(new AnalyticsFeatureParser());
+        currentFeatureParser = featureParsers.get(0);
+        currentParserManagerIndex = new SimpleObjectProperty<>(currentFeatureParser.getTabIndex());
     }
 
     /**
@@ -98,33 +98,33 @@ public class IchiFundParser {
 
     /**
      * Checks if user input is for tab switching and performs tab switching.
-     * Otherwise, passes user input into the current {@code ParserManager} for parsing.
+     * Otherwise, passes user input into the current {@code FeatureParser} for parsing.
      *
      * @return The command based on the user input. EmptyCommand for tab switching.
-     * @throws ParseException If the user input does not conform the expected format for the {@code ParserManager}
+     * @throws ParseException If the user input does not conform the expected format for the {@code FeatureParser}
      */
     private Command handleFeatureCommand(String commandWord, String arguments) throws ParseException {
         boolean isTabSwitchCommand = false;
 
-        for (ParserManager parserManager : parserManagers) {
-            if (parserManager.getTabSwitchCommandWord().equals(commandWord)) {
+        for (FeatureParser featureParser : featureParsers) {
+            if (featureParser.getTabSwitchCommandWord().equals(commandWord)) {
                 isTabSwitchCommand = true;
-                setParserManager(parserManager.getTabIndex());
+                setParserManager(featureParser.getTabIndex());
             }
         }
 
         if (!isTabSwitchCommand) {
-            return currentParserManager.parseCommand(commandWord, arguments);
+            return currentFeatureParser.parseCommand(commandWord, arguments);
         }
 
         return new EmptyCommand();
     }
 
     public void setParserManager(int index) {
-        ParserManager parserManager = parserManagers.get(index);
-        assert(parserManager.getTabIndex() == index);
-        currentParserManager = parserManager;
-        currentParserManagerIndex.setValue(currentParserManager.getTabIndex());
+        FeatureParser featureParser = featureParsers.get(index);
+        assert(featureParser.getTabIndex() == index);
+        currentFeatureParser = featureParser;
+        currentParserManagerIndex.setValue(currentFeatureParser.getTabIndex());
     }
 
     public ObservableValue<Integer> getCurrentParserManagerIndex() {

--- a/src/main/java/seedu/ichifund/logic/parser/analytics/AnalyticsFeatureParser.java
+++ b/src/main/java/seedu/ichifund/logic/parser/analytics/AnalyticsFeatureParser.java
@@ -3,13 +3,13 @@ package seedu.ichifund.logic.parser.analytics;
 import static seedu.ichifund.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
 import seedu.ichifund.logic.commands.Command;
-import seedu.ichifund.logic.parser.ParserManager;
+import seedu.ichifund.logic.parser.FeatureParser;
 import seedu.ichifund.logic.parser.exceptions.ParseException;
 
 /**
  * Passes user input to the appropriate Parser for commands related to the analytics feature.
  */
-public class AnalyticsParserManager implements ParserManager {
+public class AnalyticsFeatureParser implements FeatureParser {
 
     private final int tabIndex = 4;
 

--- a/src/main/java/seedu/ichifund/logic/parser/budget/BudgetFeatureParser.java
+++ b/src/main/java/seedu/ichifund/logic/parser/budget/BudgetFeatureParser.java
@@ -5,13 +5,13 @@ import static seedu.ichifund.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import seedu.ichifund.logic.commands.Command;
 import seedu.ichifund.logic.commands.budget.AddBudgetCommand;
 import seedu.ichifund.logic.commands.budget.DeleteBudgetCommand;
-import seedu.ichifund.logic.parser.ParserManager;
+import seedu.ichifund.logic.parser.FeatureParser;
 import seedu.ichifund.logic.parser.exceptions.ParseException;
 
 /**
  * Passes user input to the appropriate Parser for commands related to the budget feature.
  */
-public class BudgetParserManager implements ParserManager {
+public class BudgetFeatureParser implements FeatureParser {
 
     private final int tabIndex = 2;
 

--- a/src/main/java/seedu/ichifund/logic/parser/loan/LoanFeatureParser.java
+++ b/src/main/java/seedu/ichifund/logic/parser/loan/LoanFeatureParser.java
@@ -3,13 +3,13 @@ package seedu.ichifund.logic.parser.loan;
 import static seedu.ichifund.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
 import seedu.ichifund.logic.commands.Command;
-import seedu.ichifund.logic.parser.ParserManager;
+import seedu.ichifund.logic.parser.FeatureParser;
 import seedu.ichifund.logic.parser.exceptions.ParseException;
 
 /**
  * Passes user input to the appropriate Parser for commands related to the loan feature.
  */
-public class LoanParserManager implements ParserManager {
+public class LoanFeatureParser implements FeatureParser {
 
     private final int tabIndex = 3;
 

--- a/src/main/java/seedu/ichifund/logic/parser/repeater/RepeaterFeatureParser.java
+++ b/src/main/java/seedu/ichifund/logic/parser/repeater/RepeaterFeatureParser.java
@@ -5,13 +5,13 @@ import static seedu.ichifund.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import seedu.ichifund.logic.commands.Command;
 import seedu.ichifund.logic.commands.repeater.AddRepeaterCommand;
 import seedu.ichifund.logic.commands.repeater.DeleteRepeaterCommand;
-import seedu.ichifund.logic.parser.ParserManager;
+import seedu.ichifund.logic.parser.FeatureParser;
 import seedu.ichifund.logic.parser.exceptions.ParseException;
 
 /**
  * Passes user input to the appropriate Parser for commands related to the repeater feature.
  */
-public class RepeaterParserManager implements ParserManager {
+public class RepeaterFeatureParser implements FeatureParser {
 
     private final int tabIndex = 1;
 

--- a/src/main/java/seedu/ichifund/logic/parser/transaction/TransactionFeatureParser.java
+++ b/src/main/java/seedu/ichifund/logic/parser/transaction/TransactionFeatureParser.java
@@ -5,13 +5,13 @@ import static seedu.ichifund.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import seedu.ichifund.logic.commands.Command;
 import seedu.ichifund.logic.commands.transaction.AddTransactionCommand;
 import seedu.ichifund.logic.commands.transaction.FilterTransactionCommand;
-import seedu.ichifund.logic.parser.ParserManager;
+import seedu.ichifund.logic.parser.FeatureParser;
 import seedu.ichifund.logic.parser.exceptions.ParseException;
 
 /**
  * Passes user input to the appropriate Parser for commands related to the transaction feature.
  */
-public class TransactionParserManager implements ParserManager {
+public class TransactionFeatureParser implements FeatureParser {
 
     private final int tabIndex = 0;
 

--- a/src/main/java/seedu/ichifund/ui/MainWindow.java
+++ b/src/main/java/seedu/ichifund/ui/MainWindow.java
@@ -33,7 +33,7 @@ public class MainWindow extends UiPart<Stage> {
 
     private Stage primaryStage;
     private Logic logic;
-    private ObservableValue<Integer> currentParserManagerIndex;
+    private ObservableValue<Integer> currentFeatureParserIndex;
 
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
@@ -91,7 +91,7 @@ public class MainWindow extends UiPart<Stage> {
         // Set dependencies
         this.primaryStage = primaryStage;
         this.logic = logic;
-        this.currentParserManagerIndex = logic.getCurrentParserManagerIndex();
+        this.currentFeatureParserIndex = logic.getCurrentFeatureParserIndex();
         setupParserSwitching();
 
         // Configure the UI
@@ -103,13 +103,13 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     private void setupParserSwitching() {
-        // Add listener to check when Logic changes parserManagerIndex.
-        this.currentParserManagerIndex.addListener(new ParserManagerIndexListener(mainTabPane));
+        // Add listener to check when Logic changes currentFeatureParserIndex.
+        this.currentFeatureParserIndex.addListener(new FeatureParserIndexListener(mainTabPane));
 
-        // When tab switching is done by a mouse click, this we change parserManagerIndex through Logic.
+        // When tab switching is done by a mouse click, this we change currentFeatureParserIndex through Logic.
         mainTabPane.setOnMouseClicked(event -> {
             int selectedIndex = mainTabPane.getSelectionModel().getSelectedIndex();
-            logic.setParserManager(selectedIndex);
+            logic.setFeatureParser(selectedIndex);
         });
     }
 
@@ -213,8 +213,8 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     public void handleShowTransaction() {
-        // This triggers an invalidation event in ParserManagerIndexListener, resulting in a tab switch.
-        logic.setParserManager(0);
+        // This triggers an invalidation event in FeatureParserIndexListener, resulting in a tab switch.
+        logic.setFeatureParser(0);
     }
 
     /**
@@ -222,8 +222,8 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     public void handleShowRepeater() {
-        // This triggers an invalidation event in ParserManagerIndexListener, resulting in a tab switch.
-        logic.setParserManager(1);
+        // This triggers an invalidation event in FeatureParserIndexListener, resulting in a tab switch.
+        logic.setFeatureParser(1);
     }
 
     /**
@@ -231,8 +231,8 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     public void handleShowBudget() {
-        // This triggers an invalidation event in ParserManagerIndexListener, resulting in a tab switch.
-        logic.setParserManager(2);
+        // This triggers an invalidation event in FeatureParserIndexListener, resulting in a tab switch.
+        logic.setFeatureParser(2);
     }
 
     /**
@@ -240,8 +240,8 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     public void handleShowLoan() {
-        // This triggers an invalidation event in ParserManagerIndexListener, resulting in a tab switch.
-        logic.setParserManager(3);
+        // This triggers an invalidation event in FeatureParserIndexListener, resulting in a tab switch.
+        logic.setFeatureParser(3);
     }
 
     /**
@@ -249,8 +249,8 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     public void handleShowAnalytics() {
-        // This triggers an invalidation event in ParserManagerIndexListener, resulting in a tab switch.
-        logic.setParserManager(4);
+        // This triggers an invalidation event in FeatureParserIndexListener, resulting in a tab switch.
+        logic.setFeatureParser(4);
     }
 
     /**
@@ -309,19 +309,19 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * Listener for invalidation of currentParserManager.
+     * Listener for invalidation of currentFeatureParserIndex.
      */
-    private class ParserManagerIndexListener implements InvalidationListener {
+    private class FeatureParserIndexListener implements InvalidationListener {
         private TabPane tabPane;
 
-        public ParserManagerIndexListener(TabPane tabpane) {
+        public FeatureParserIndexListener(TabPane tabpane) {
             this.tabPane = tabpane;
         }
 
         @Override
         public void invalidated(Observable observable) {
             // Change tabs in TabPane
-            this.tabPane.getSelectionModel().select(currentParserManagerIndex.getValue());
+            this.tabPane.getSelectionModel().select(currentFeatureParserIndex.getValue());
         }
     }
 }


### PR DESCRIPTION
This is to avoid the use of the word "Manager" which is chiefly used to distinguish implementation from interface of Logic, Ui, and Model.